### PR TITLE
パスワード再設定テスト作成

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :user do
-    
+    name { "test_user" }
+    role { "general" }
+    email { "example@email.com" }
+    password { "password" }
+    password_confirmation { "password" }
   end
 end

--- a/spec/system/password_resets_spec.rb
+++ b/spec/system/password_resets_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'パスワードリセット', type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'パスワードの変更' do
+    it 'パスワードが変更できる' do
+      visit new_user_password_path
+      fill_in 'メールアドレス', with: user.email
+      click_button '再設定メール送信'
+      expect(page).to have_content('パスワードリセット手順を送信しました')
+
+      user.reload
+      visit edit_user_password_path(reset_password_token: user.reset_password_token)
+      fill_in 'パスワード(6文字以上)', with: '123456789'
+      fill_in 'パスワード(入力確認)', with: '123456789'
+      click_button '更新'
+      expect(page).to have_current_path(new_user_session_path, ignore_query: true), 'パスワードリセット後にログイン画面に遷移していません'
+      expect(page).to have_content('パスワードを変更しました'), 'フラッシュメッセージ「パスワードを変更しました」が表示されていません'
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe "Users", type: :system do
           expect(page).to have_content('名前を入力してください')
           expect(page).to have_content('メールアドレスを入力してください')
           expect(page).to have_content('パスワードを入力してください')
-          expect(page).to have_content('パスワード（入力確認）を入力してください')
+          expect(page).to have_content('パスワード(入力確認)を入力してください')
       end
     end
   end
 
   describe 'ログイン' do
-    let!(:user) { create(:user, role: :general, name: 'test_user', email: 'example@email.com', password: 'password', password_confirmation: 'password') }
+    let!(:user) { FactoryBot.create(:user) }
 
     context '正常な入力の場合' do
       it 'ログインできること' do


### PR DESCRIPTION
## 概要

パスワード再設定のテスト作成

---

## 関連 Issue

- close #24 

---

## 変更内容

- [x] パスワード再設定のシステムスペックテストを作成
- [x] User の FactoryBot を作成


---

## 備考
なし
