### PR TITLE
家族ルーム作成機能テスト作成

### DIFF
--- a/app/views/rooms/home.html.erb
+++ b/app/views/rooms/home.html.erb
@@ -9,5 +9,3 @@
 </p>
 
 <%= link_to "家族ルーム作成", new_room_path %>
-
-<%= link_to "家族ルーム編集", edit_room_path %>

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :room do
-    name { "MyString" }
-    host_user_id { 1 }
+    name { "test_room" }
+    entry_word { "テストの合言葉" }
+    association :host_user, factory: :user
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,9 @@ RSpec.configure do |config|
 
   config.use_transactional_fixtures = true
 
+  # ログイン処理のモジュールを読み込み。
+  config.include SystemLoginHelpers, type: :system
+
   config.filter_rails_from_backtrace!
   config.include FactoryBot::Syntax::Methods
   # system spec はデフォルトでは rack_test で動かす（ブラウザなし）

--- a/spec/support/system_login_helpers.rb
+++ b/spec/support/system_login_helpers.rb
@@ -1,0 +1,9 @@
+# ログインの処理をモジュール化。( ChatGPT作 )
+module SystemLoginHelpers
+  def login_as_user(user)
+    visit new_user_session_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード(6文字以上)', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/spec/system/rooms_spec.rb
+++ b/spec/system/rooms_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "Rooms", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    login_as_user(user)
+  end
+
+  describe '家族ルームの作成' do
+    context '正常な入力の場合' do
+      it '家族ルームが作成出来ること' do
+        visit new_room_path
+
+        expect {
+          fill_in '家族ルーム名', with: 'test_room'
+          fill_in '合言葉', with: 'テストの合言葉'
+          click_button '作成'
+        }.to change(Room, :count).by(1)
+
+        expect(page).to have_content '家族ルームを作成しました'
+        # host_user がホストになっているかチェック
+        expect(Room.last.host_user).to eq user
+      end
+    end
+
+    context '異常な入力の場合' do
+      it '家族ルームを作成出来ない' do
+        visit new_room_path
+
+        expect {
+          click_button '作成'
+        }.not_to change(Room, :count)
+
+        expect(page).to have_content('家族ルーム名を入力してください')
+        expect(page).to have_content('合言葉を入力してください')
+      end
+    end
+  end
+
+  describe '家族ルームの削除' do
+    let(:room) { FactoryBot.create(:room, host_user: user) }
+
+    it '家族ルームを削除できること' do
+        visit edit_room_path(room)
+
+        expect {
+          click_button 'この家族ルームを削除'
+          click_button '承知の上で削除'
+        }.to change(Room, :count).by(-1)
+        expect(page).to have_content('家族ルームを削除しました')
+    end
+  end
+end
+
+# let(:user) { FactoryBot.create(:user) }
+# let(:room) { FactoryBot.create(:room, host_user: user) }
+# この2行の組み合わせで、DBには User が1人作られ Room が1つ作られる
+# その Room の host_user_id には、その user.id が入る


### PR DESCRIPTION
## 概要

家族ルーム作成、削除のテストを作成

---

## 関連 Issue

- close #30 

---

## 変更内容

- [ ] rooms_spec追加
- [ ] FactoryBot 追加
- [ ] ログイン処理のモジュール作成

---

## 備考
実装がまだなのでテストはエラーとなる。
