### PR TITLE
合言葉を廃止

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -40,7 +40,7 @@ class RoomsController < ApplicationController
   private
 
   def room_params
-    params.require(:room).permit(:name, :entry_word)
+    params.require(:room).permit(:name)
   end
 
   def set_have_room

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -6,7 +6,6 @@ class Room < ApplicationRecord
 
   ##### バリデーション #####
   validates :name, presence: true, length: { maximum: 20 }
-  validates :entry_word, presence: true, length: { minimum: 4, maximum: 20 }
 
   ##### アソシエーション #####
   has_many :users

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -7,11 +7,6 @@
     <%= f.text_field :name %>
   </div>
 
-  <div class="field">
-    <%= f.label :entry_word %>
-    <%= f.text_field :entry_word %>
-  </div>
-
   <div class="actions">
     <%= f.submit t('.submit') %>
   </div>

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -1,10 +1,9 @@
 <h1>家族ルーム "作成" 画面</h1>
 
 <p>この画面で実装するもの。
-・家族ルーム名入力フォーム 済
-・合言葉の入力フォーム 済
-・ルームアイコンのファイル選択ボタン
-・「作成」ボタン 済
+<li>・家族ルーム名入力フォーム 済</li>
+<li>・ルームアイコンのファイル選択ボタン</li>
+<li>・「作成」ボタン 済</li>
 </p>
 
 
@@ -24,11 +23,6 @@
   <div class="field">
     <%= form.label :name %>
     <%= form.text_field :name %>
-  </div>
-
-  <div class="field">
-    <%= form.label :entry_word %>
-    <%= form.text_field :entry_word %>
   </div>
 
   <div class="actions">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,7 +17,6 @@ ja:
         updated_at: 更新日
       room:
         name: 家族ルーム名
-        entry_word: 合言葉
     models:
       user: ユーザー
       room: 家族ルーム

--- a/db/migrate/20251210042656_remove_entry_word_from_rooms.rb
+++ b/db/migrate/20251210042656_remove_entry_word_from_rooms.rb
@@ -1,0 +1,5 @@
+class RemoveEntryWordFromRooms < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :rooms, :entry_word, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_09_113911) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_10_042656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,7 +25,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_09_113911) do
 
   create_table "rooms", force: :cascade do |t|
     t.string "name", null: false
-    t.string "entry_word", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :room do
     name { "test_room" }
-    entry_word { "テストの合言葉" }
   end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Room, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  #pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/system/rooms_spec.rb
+++ b/spec/system/rooms_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Rooms", type: :system do
 
         expect {
           fill_in '家族ルーム名', with: 'test_room'
-          fill_in '合言葉', with: 'テストの合言葉'
           click_button '作成'
         }.to change(Room, :count).by(1)
 
@@ -32,7 +31,6 @@ RSpec.describe "Rooms", type: :system do
         }.not_to change(Room, :count)
 
         expect(page).to have_content('家族ルーム名を入力してください')
-        expect(page).to have_content('合言葉を入力してください')
       end
     end
   end
@@ -58,7 +56,6 @@ RSpec.describe "Rooms", type: :system do
       visit edit_room_path(room)
 
         fill_in '家族ルーム名', with: 'test_room_change'
-        fill_in '合言葉', with: 'テストの合言葉変更'
         click_button '更新'
 
         expect(page).to have_content('家族ルームを更新しました')
@@ -66,7 +63,6 @@ RSpec.describe "Rooms", type: :system do
         # DBの中身が本当に変わったか確認
         room.reload
         expect(room.name).to eq 'test_room_change'
-        expect(room.entry_word).to eq 'テストの合言葉変更'
     end
   end
 end


### PR DESCRIPTION
## 概要

家族ルームはトークンによる認証にした為、合言葉を廃止

---

## 関連 Issue

- close #215 


---

## 変更内容

- [ ] entry_word カラムを削除
- [ ] ストロングパラメーターを削除
- [ ] ビューのフォームを削除
- [ ] バリデーションを削除
- [ ] テストを修正

---

## 備考
テスト通過。ブラウザの動きについても正常。
