### PR TITLE
家族ルームの仕様変更の実装完了

### DIFF
--- a/app/assets/stylesheets/invitations.css
+++ b/app/assets/stylesheets/invitations.css
@@ -169,7 +169,7 @@
 /* --- 参加画面用（Edit） --- */
 .join-room-name {
   font-family: 'Yuji Syuku', serif;
-  font-size: 2.5rem;
+  font-size: 1.5rem;
   color: #1F2F54;
   margin: 1.5rem 0;
   padding: 1rem;
@@ -214,4 +214,11 @@
 .btn-back-text:hover {
   color: #1F2F54;
   border-bottom-color: #1F2F54;
+}
+
+/*----- 警告アラート ------ */
+.invitation-switch-alert{
+  background: #fff !important;
+  color: #111827 !important;
+  border: 1px solid #f50b0b !important;
 }

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -33,19 +33,27 @@ class InvitationsController < ApplicationController
   def edit; end
 
   def update
-    # 招待されたのが子ユーザーであれば、切り替え不可。
-    if current_user.child?
-      flash[:danger] = '子ユーザーは招待リンクから家族ルームを切り替えできません'
+
+    # 既に、同じ家族ルームに参加している場合。
+    if current_user.room_id == @room.id
+      flash[:danger] = '既にこの家族ルームに参加しています'
       return redirect_to home_rooms_path
     end
 
-    if current_user.room_id == @room.id
-      flash[:danger] = '既にこの家族ルームに参加しています'
-    else
-      current_user.update!(room: @room)
-      flash[:notice] = "#{@room.name} に参加しました"
+    # needs_switch 現在のユーザーがルームに属している、かつ、そのルームが招待ルームと違う。
+    needs_switch = current_user.room_id.present? && current_user.room_id != @room.id
+    # confirm は「はい」を選択すれば params に含まれる(invitation/edit に記述)
+    if needs_switch && params[:confirm].blank?
+      # @show_switch_warning は view で条件分岐をする際に使用。
+      @show_switch_warning = true
+      # status: :unprocessable_entity は ステータスコード 422 でリダイレクトするという意味。
+      return render :edit, status: :unprocessable_entity
     end
+
+    current_user.update!(room: @room)
+    flash[:notice] = "#{@room.name} に参加しました"
     redirect_to home_rooms_path
+
   end
 
   private

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -36,8 +36,20 @@ class RoomsController < ApplicationController
   end
 
   def destroy
-    @room.destroy!
-    flash[:notice] = "家族ルームを削除しました"
+
+    if params[:confirm].blank?
+      @show_warning = true
+      return render :edit, status: :unprocessable_entity
+    end
+
+    current_user.update!(room: nil)
+
+    # @room が存在して、ユーザーが誰も居ないなら @room を削除。
+    if @room.present? && @room.users.reload.none?
+      @room.destroy!
+    end
+
+    flash[:notice] = "家族ルームを退出しました"
     redirect_to home_rooms_path
   end
 

--- a/app/views/invitations/edit.html.erb
+++ b/app/views/invitations/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="invitation-container animate-fade-in">
-
   <div class="invitation-card">
 
     <p class="text-gray-500 font-bold mb-2">以下の家族ルームへ招待されています</p>
 
+    <!--------- 招待されているルームの名前 ---------->
     <h1 class="join-room-name">
       <%= @room.name %>
     </h1>
@@ -13,12 +13,45 @@
       家族と共に詐欺対策の稽古を始めますか？
     </p>
 
-    <div class="my-8">
-      <%= button_to room_invitation_path(@room, @invitation, token: params[:token]), method: :patch, class: "btn-primary-action w-full" do %>
-        入門する（参加）
-      <% end %>
-    </div>
+    <!----------- ルーム切り替えのアラート ------------->
+    <% if @show_switch_warning %>
+      <!----------- daisy UI のアラート --------->
+      <div role="alert" class="alert sm:alert-horizontal mb-6 invitation-switch-alert">
+        <svg  xmlns="http://www.w3.org/2000/svg"
+              fill="none" viewBox="0 0 24 24"
+              class="stroke-warning h-6 w-6 shrink-0">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+
+        <!----------- アラートの本文 ------------>
+        <span>現在所属の家族ルームは退室となります。<br>よろしいですか？</span>
+
+        <!---------- 「いいえ」ボタン --------->
+        <div class="flex gap-2">
+          <%= link_to "いいえ",
+                home_path,
+                class: "btn btn-sm btn-error" %>
+
+        <!---------- 「はい」ボタン ---------->
+          <%= button_to "はい",
+                room_invitation_path(@room, @invitation, token: params[:token], confirm: 1),
+                method: :patch,
+                class: "btn btn-sm btn-success" %>
+        </div>
+      </div>
+    <% end %>
+
+    <!---------- ルームに属していない場合(アラートなし) ---------->
+    <% unless @show_switch_warning %>
+      <div class="my-8">
+        <%= button_to room_invitation_path(@room, @invitation, token: params[:token]),
+              method: :patch,
+              class: "btn-primary-action w-full" do %>
+          入門する（参加）
+        <% end %>
+      </div>
+    <% end %>
 
   </div>
-
 </div>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -13,11 +13,38 @@
 
 <% end %>
 
-<div class="delete_actions">
-  <%= button_to t('.destroy'),
-                room_path(@room),
+  <% if @show_warning %>
+        <!----------- daisy UI のアラート --------->
+      <div role="alert" class="alert sm:alert-horizontal mb-6 invitation-switch-alert">
+        <svg  xmlns="http://www.w3.org/2000/svg"
+              fill="none" viewBox="0 0 24 24"
+              class="stroke-warning h-6 w-6 shrink-0">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M12 9v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+
+        <!----------- アラートの本文 ------------>
+        <span>現在所属の家族ルームから退室します。<br>本当によろしいですか？</span>
+
+        <!---------- 「いいえ」ボタン --------->
+        <div class="flex gap-2">
+          <%= link_to "いいえ",
+                home_rooms_path,
+                class: "btn btn-sm btn-error" %>
+
+        <!---------- 「はい」ボタン ---------->
+          <%= button_to "はい",
+                room_path(@room, confirm: 1),
                 method: :delete,
-                data: { confirm: '本当にこの家族ルームを削除してもよろしいですか？' } %>
-</div>
+                class: "btn btn-sm btn-success" %>
+        </div>
+      </div>
+    <% end %>
+
+  <% unless @show_warning %>
+    <%= button_to "この家族ルームから退室する",
+        room_path(@room),
+        method: :delete %>
+  <% end %>
 
 <%= link_to "戻る", home_rooms_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   ##### 家族ルームのルーティング #####
   resources :rooms, only: %i[new create edit update destroy] do
+    # collection は id を持たないルーティングを生成。（その逆はmember)
     collection do
       get :home
     end


### PR DESCRIPTION
## 概要

家族ルームに属している状態で招待を受けた場合。
アラートが表示され、「現在所属の家族ルームは退室となります。よろしいですか？」と表示される。

家族ルーム退室機能を追加。
家族ルームに属する人が居なくなったら、ルームが削除される。

---

## 関連 Issue

- close #307

---

## 変更内容

- [ ] invitations.css 編集
- [ ] rooms , invitations controller 編集
- [ ]  rooms , invitations edit.html.erb 編集


---

## 備考

