### PR TITLE
クイズ解説のCSS編集

### DIFF
--- a/app/assets/stylesheets/quizzes.css
+++ b/app/assets/stylesheets/quizzes.css
@@ -262,3 +262,12 @@
 .next-btn:hover {
   background-color: #a03024;
 }
+
+/***** 解説文 *****/
+.quiz-explanation{
+  color: #374151;
+  line-height: 1.625;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -124,7 +124,7 @@
         <% if @quiz.explanation.present? %>
           <div>
             <span class="explanation-title">【解説】</span>
-            <p class="text-gray-700 leading-relaxed whitespace-pre-wrap"><%= @quiz.explanation %></p>
+            <p class="quiz-explanation"><%= @quiz.explanation %></p>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
## 概要

クイズ解説のURLが折り返し表示されない問題を解決。

---

## 関連 Issue

- close #345 

---

## 変更内容

- [ ] quizzes.css 編集 
- [ ] quizzes/show.html.erb 編集


---

## 備考

