### PR TITLE
成績履歴は２０件上限

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -30,7 +30,7 @@ class ResultsController < ApplicationController
     user_result = user_result.where(courses: { category_id: params[:category_id] }) if params[:category_id].present?
 
     # 絞り込みの結果をインスタンス変数に代入している。N + 1 対策済み
-    @course_results = user_result.includes(:course).order(created_at: :desc).page(params[:page]).per(10)
+    @course_results = user_result.includes(:course).order(created_at: :desc).page(params[:page]).per(5)
   end
 
   def show

--- a/app/models/course_result.rb
+++ b/app/models/course_result.rb
@@ -56,6 +56,11 @@ class CourseResult < ApplicationRecord
       # increment! は ActiveRecord の数値カラムを加算し、保存するメソッド。
       user.increment!(:total_point, get_point)
     end
+
+    # 成績履歴を20件に制限（21件目以降は古いのを削除）
+    excess = user.course_results.order(created_at: :desc).offset(20)
+    excess.delete_all
+
     # メソッドの戻り値
     course_result
   end

--- a/db/migrate/20260205101119_add_cascade_to_course_results_dependencies.rb
+++ b/db/migrate/20260205101119_add_cascade_to_course_results_dependencies.rb
@@ -1,0 +1,19 @@
+class AddCascadeToCourseResultsDependencies < ActiveRecord::Migration[7.2]
+  def up
+    # quiz_histories -> course_results
+    remove_foreign_key :quiz_histories, :course_results
+    add_foreign_key :quiz_histories, :course_results, on_delete: :cascade
+
+    # quiz_history_choices -> quiz_histories
+    remove_foreign_key :quiz_history_choices, :quiz_histories
+    add_foreign_key :quiz_history_choices, :quiz_histories, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :quiz_histories, :course_results
+    add_foreign_key :quiz_histories, :course_results
+
+    remove_foreign_key :quiz_history_choices, :quiz_histories
+    add_foreign_key :quiz_history_choices, :quiz_histories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_09_070218) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_05_101119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -171,10 +171,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_09_070218) do
   add_foreign_key "invitations", "rooms"
   add_foreign_key "quiz_categories", "categories"
   add_foreign_key "quiz_categories", "quizzes"
-  add_foreign_key "quiz_histories", "course_results"
+  add_foreign_key "quiz_histories", "course_results", on_delete: :cascade
   add_foreign_key "quiz_histories", "quizzes"
   add_foreign_key "quiz_histories", "users"
   add_foreign_key "quiz_history_choices", "choices"
-  add_foreign_key "quiz_history_choices", "quiz_histories"
+  add_foreign_key "quiz_history_choices", "quiz_histories", on_delete: :cascade
   add_foreign_key "users", "rooms"
 end


### PR DESCRIPTION
## 概要

成績履歴は上限２０件に設定。
古いものは削除・

---

## 関連 Issue

- close #349 

---

## 変更内容

- [ ] マイグレーションファイル作成、実行
- [ ] course_result.rb に最大２０件のロジック追加

---

## 備考

上限１０件じゃあ寂しい気がして、上限２０件にしました。
