### PR TITLE
リンク失効ページ実装

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -51,6 +51,7 @@ class ResultsController < ApplicationController
     end
 
     # この成績(@course_result)専用の「共有トークン」を作る。
+    # .signed_id でトークンを作成している（Rails標準機能）
     token = @course_result.signed_id(purpose: :share_result, expires_in: 30.days)
 
     # 上で作った token をURLに埋め込んで、共有用URLを作る。

--- a/app/controllers/share_results_controller.rb
+++ b/app/controllers/share_results_controller.rb
@@ -20,20 +20,24 @@ class ShareResultsController < ApplicationController
   private
 
   # 共有URLに含まれる token から、対応する成績データを取り出すメソッド
+  # find_signed で params で受け取ったトークンを検証。問題なければ return でメソッド終了。
   def set_course_result_from_token
     @course_result = CourseResult.includes(course: :category)
-                                 .find_signed(params[:token], purpose: :share_result)
+                                  .find_signed(params[:token], purpose: :share_result)
     return if @course_result.present?
 
+    # トークン検証で問題がある場合。
     render_expired_page
   end
 
+  # リンク有効期限切れ、（30日）もしくは、成績が消去されていた場合
   def render_expired_page
     helpers.assign_meta_tags(
       title: "共有リンクの有効期限が切れました",
       description: "共有された成績リンクは有効期限切れ、または無効です。",
       url: request.original_url
     )
+    # expiredページを表示。status: :gone でステータス 410
     render :expired, status: :gone
   end
 end

--- a/app/views/share_results/expired.html.erb
+++ b/app/views/share_results/expired.html.erb
@@ -1,9 +1,8 @@
 <div class="result-container animate-fade-in">
   <section class="share-expired-card">
-    <h1 class="share-expired-title">共有リンクの有効期限が切れました</h1>
+    <h1 class="share-expired-title">この成績リンクは利用できません。</h1>
     <p class="share-expired-text">
-      この成績リンクは利用できません。<br>
-      最新の成績画面から新しい共有リンクを発行してください。
+      共有リンクの有効期限が切れ、もしくは成績が削除されました。<br>
     </p>
 
     <div class="share-expired-actions">


### PR DESCRIPTION
## 概要

OGPのリンク失効、成績削除された場合のページを作成

---

## 関連 Issue

- close #370 

---

## 変更内容

- [ ] share_results_controller.rb を編集
- [ ] share/expired.html.erb 作成

---

## 備考

