### PR TITLE
エラー修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   # 新しいURLへリダイレクトさせるメソッド
   def redirect_to_custom_domain
     if Rails.env.production? && request.host != "sagi-taisaku.com"
-      redirect_to "https://sagi-taisaku.com#{request.path}", status: :moved_permanently
+      redirect_to "https://sagi-taisaku.com#{request.path}", status: :moved_permanently, allow_other_host: true
     end
   end
 


### PR DESCRIPTION
## 概要

Rails のセキュリティで、別ドメインへのリダイレクトが禁止になっていた。
なので、別ドメインでもリダイレクト可能に修正。

---

## 関連 Issue

- #433

---

## 変更内容

- [ ] redirect_to_custom_domain に allow_other_host: true を追記。

---

## 備考

