### PR TITLE
prepare_quiz_session修正

### DIFF
--- a/app/assets/stylesheets/courses.css
+++ b/app/assets/stylesheets/courses.css
@@ -51,6 +51,10 @@
   box-shadow: 4px 4px 0px rgba(31, 47, 84, 0.15); /* 控えめな和風影 */
   position: relative;
   overflow: hidden;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+  box-sizing: border-box;
 }
 
 /* ホバー時の挙動 */

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,10 +1,15 @@
 class QuizzesController < ApplicationController
   # 未ログインでも、クイズに挑戦できる。
-  skip_before_action :authenticate_user!, only: [ :show, :answer, :guest_result ]
+  skip_before_action :authenticate_user!, only: [ :start, :show, :answer, :guest_result ]
 
   before_action :set_course
-  before_action :prepare_quiz_session, only: :show
   before_action :set_index, :set_quiz_id, :set_quiz, :set_choices, only: [ :show, :answer ]
+
+  def start
+    session[:quiz_ids] = @course.quizzes.order("RANDOM()").pluck(:id)
+    session[:answers] = []
+    redirect_to course_quiz_path(@course, 1)
+  end
 
   def show
     # 答え合わせのメソッドを実行（ブラウザの「戻る」で回答済みを復元）
@@ -80,26 +85,6 @@ class QuizzesController < ApplicationController
   # どのコースをプレイ中か特定している。
   def set_course
     @course = Course.find(params[:course_id])
-  end
-
-  # 一度のプレイで出す問題リストを session に用意する。
-  def prepare_quiz_session
-    # クイズ開始ボタンから来たとき（クエリパラメータに quiz_start=true 付き）
-    if params[:quiz_start].present?
-      # セッションをリセットしている
-      session[:quiz_ids] = nil
-      session[:answers] = []
-      # courses/:course_id/play/:id にリダイレクトしている。
-      redirect_to course_quiz_path(@course, 1)
-      # redirect なので return で終了させる必要がある。
-      return
-    end
-
-    # session[:quiz_ids] が空の場合、コース内のクイズをランダムに並べて、idだけの配列にする。
-    if session[:quiz_ids].blank?
-      # コース内のクイズをランダム順にして、idだけの配列にする。
-      session[:quiz_ids] = @course.quizzes.order("RANDOM()").pluck(:id)
-    end
   end
 
   # 今、何問目のクイズをしているのか@index に代入している。

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -14,7 +14,7 @@
     <div class="course-list">
       <% @courses.each do |course| %>
         <%# カード全体をリンクにする %>
-        <%= link_to course_quiz_path(course, 1, quiz_start: true), class: "course-card group" do %>
+        <%= button_to start_course_quiz_index_path(course), method: :post, class: "course-card group" do %>
 
           <div class="course-info">
             <%# --- バッジ表示エリア（レイアウト崩れを防ぐためコース名の上に配置） --- %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     resources :quiz, only: [ :show ], controller: "quizzes" do
       post :answer, on: :member
       get :guest_result, on: :collection
+      post :start, on: :collection
     end
   end
 

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -43,12 +43,15 @@ RSpec.describe "Quizzes", type: :system do
   let!(:expected_total_point) { expected_correct_count * 10 }
 
   before do
-    # 出題順を固定化するため、session[:quiz_ids] に作成順のIDを直接入れる。
+    # 出題順を固定化するため、RANDOM() の代わりに作成順のIDを返すようスタブする。
     fixed_quiz_ids = quizzes.map(&:id)
-    allow_any_instance_of(QuizzesController).to receive(:prepare_quiz_session) do |controller|
-      controller.session[:quiz_ids] ||= fixed_quiz_ids
-      controller.session[:answers] ||= []
-    end
+    allow_any_instance_of(Course).to receive_message_chain(:quizzes, :order, :pluck).and_return(fixed_quiz_ids)
+  end
+
+  # コース一覧からクイズを開始する共通処理（POST の start アクションを経由する）。
+  def start_quiz
+    visit category_courses_path(category)
+    find('button.course-card').click
   end
 
   # 5問回答して結果リンク表示まで進める共通処理。
@@ -75,7 +78,7 @@ RSpec.describe "Quizzes", type: :system do
 
   describe 'ゲストでのクイズ挑戦' do
     it '固定順で5問出題され、ゲスト結果画面まで進めること' do
-      visit course_quiz_path(course, 1)
+      start_quiz
       answer_all_questions(answer_choice_texts)
       click_link '結果を確認する'
 
@@ -96,7 +99,7 @@ RSpec.describe "Quizzes", type: :system do
     end
 
     it '固定順で5問回答し、成績詳細画面で結果を確認できること' do
-      visit course_quiz_path(course, 1)
+      start_quiz
       answer_all_questions(answer_choice_texts)
       click_link '結果を確認する'
 


### PR DESCRIPTION
## 概要

QuizzesController のリファクタリング
prepare_quiz_session メソッドを削除し、新たに start アクションを追加。

---

## 関連 Issue

- #460

---

## 変更内容

- ルーティングに post :start, on: :collection を追加
```ruby
  resources :courses do
    resources :quiz, only: [ :show ], controller: "quizzes" do
      post :answer, on: :member
      get :guest_result, on: :collection
      post :start, on: :collection # ←追加分
    end
  end
```

- start アクションを追加
```ruby
  def start
    session[:quiz_ids] = @course.quizzes.order("RANDOM()").pluck(:id)
    session[:answers] = []
    redirect_to course_quiz_path(@course, 1)
  end
```

- courses/ index.html.erb の link_to をbutton_to に変更。
なぜなら、GET リクエストから、POST リクエストに変更したから。
```
 <%= button_to start_course_quiz_index_path(course), method: :post, class: "course-card group" do %>
```

- button_to にしたことにより、レイアウト崩れを修正
- quizzes_spec.rb 修正
---

## 備考

