### PR TITLE
answer_check修正

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -95,30 +95,20 @@ class QuizzesController < ApplicationController
     @choices = @quiz.choices
   end
 
-  # QuizAnswerEvaluator で答え合わせをしたものをインスタンス変数に渡す。
   def answer_check
     # 自分の回答を変数に代入。
     stored_answer = (session[:answers] || [])[ @index - 1 ]
 
-    # 答え合わせのクラス QuizAnswerEvaluator を呼び出している
+    # 答え合わせのインスタンスを作成し、resultに代入。
     result = QuizAnswerEvaluator.call(
       quiz: @quiz,
       answer: stored_answer
     )
 
-    # multiple_answer? と correct? メソッドは QuizAnswerEvaluator の Result で作成したメソッド。
+    # 答え合わせのインスタンスのメソッドを使い、必要なデータをセットする。
     @multiple_answer = result.multiple_answer?
     @is_correct = result.correct?
-
-    if @multiple_answer
-      ##### 複数選択肢の場合。 #####
-      # result が持つ selected_ids を @selected_choice_ids に代入。
-      @selected_choice_ids = result.selected_ids
-      @multi_correct_choices = result.correct_choices
-    else
-      ##### 単一選択の場合 #####
-      @selected_choice_id = result.selected_ids.first
-      @correct_choice = result.correct_choices.first
-    end
+    @selected_choice_ids = result.selected_ids
+    @correct_choices = result.correct_choices
   end
 end

--- a/app/views/quizzes/_answer.html.erb
+++ b/app/views/quizzes/_answer.html.erb
@@ -31,7 +31,7 @@
               name="selected_choice"
               id="choice_<%= choice.id %>"
               value="<%= choice.id %>"
-              <%= "checked" if choice.id.to_s == @selected_choice_id.to_s %>
+              <%= "checked" if @selected_choice_ids&.include?(choice.id) %>
             >
             <label for="choice_<%= choice.id %>" class="choice-label">
               <%= choice.text %>
@@ -53,7 +53,7 @@
       <div class="choice-item <%= @multiple_answer ? 'choice-item--checkbox' : '' %>">
         <input
           type="<%= @multiple_answer ? 'checkbox' : 'radio' %>"
-          <%= "checked" if (@selected_choice_ids&.include?(choice.id) || choice.id.to_s == @selected_choice_id.to_s) %>
+          <%= "checked" if @selected_choice_ids&.include?(choice.id) %>
           disabled
         >
         <label class="choice-label"><%= choice.text %></label>

--- a/app/views/quizzes/_result.html.erb
+++ b/app/views/quizzes/_result.html.erb
@@ -22,12 +22,10 @@
       <div class="mb-4">
         <span class="explanation-title text-[#C63D2F]">【正解】</span>
         <ul class="list-disc list-inside font-bold text-lg text-gray-800">
-          <% if @multi_correct_choices.present? %>
-            <% @multi_correct_choices.each do |correct| %>
+          <% if @correct_choices.present? %>
+            <% @correct_choices.each do |correct| %>
               <li><%= correct.text %></li>
             <% end %>
-          <% elsif @correct_choice.present? %>
-            <li><%= @correct_choice.text %></li>
           <% end %>
         </ul>
       </div>


### PR DESCRIPTION
## 概要

QuizzesController のanswer_check メソッドを修正。
複数回答の条件分岐を削除。

---

## 関連 Issue

- #460

---

## 変更内容

- answer_checkメソッド
変更前
```ruby
    if @multiple_answer
      ##### 複数選択肢の場合。 #####
      # result が持つ selected_ids を @selected_choice_ids に代入。
      @selected_choice_ids = result.selected_ids
      @multi_correct_choices = result.correct_choices
    else
      ##### 単一選択の場合 #####
      @selected_choice_id = result.selected_ids.first
      @correct_choice = result.correct_choices.first
    end
```

変更後
```ruby
    # 答え合わせのインスタンスのメソッドを使い、必要なデータをセットする。
    @multiple_answer = result.multiple_answer?
    @is_correct = result.correct?
    @selected_choice_ids = result.selected_ids
    @correct_choices = result.correct_choices
```

---

## 備考

その他、コメントを修正。
erbファイルの条件分岐を削除。
