### PR TITLE
answerアクション修正

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -21,20 +21,9 @@ class QuizzesController < ApplicationController
   def answer
     # session[:answers] が nil のときだけ [] にする。（エラー回避のため）
     session[:answers] ||= []
-
-    if @quiz.multiple_answer?
-      ##### 複数選択問題の場合 #####
-      # ユーザーが選択した回答 params[:selected_choice_ids]を整形して、変数に代入。
-      selected_ids = Array(params[:selected_choice_ids]).map(&:to_i).uniq
-      # 整形した回答を、session[:answers] に格納。
-      session[:answers][@index - 1] = selected_ids
-    else
-      ##### 単一選択問題の場合 #####
-      # 単一問題は、を session[:answers] に格納。
-      session[:answers][@index - 1] = params[:selected_choice]
-    end
-
-    # 答え合わせをするメソッドを実行
+    # ユーザーが選択肢した回答をセッションで管理。
+    session[:answers][@index - 1] = Array(params[:selected_choice_id]).map(&:to_i)
+    # 答え合わせをするメソッドを実行し、答え合わせオブジェクトを作成。
     answer_check
 
     # コースの最後、途中で条件を分岐。

--- a/app/services/quiz_answer_evaluator.rb
+++ b/app/services/quiz_answer_evaluator.rb
@@ -45,7 +45,7 @@ class QuizAnswerEvaluator
 
   # answer を、整数の・重複なし・並び順統一済みの配列に変える
   def selected_ids
-    @selected_ids ||= Array(answer).map(&:to_i).uniq.sort
+    @selected_ids ||= Array(answer).sort
   end
 
   # 正解選択肢の id 一覧

--- a/app/views/quizzes/_answer.html.erb
+++ b/app/views/quizzes/_answer.html.erb
@@ -11,7 +11,7 @@
           <div class="choice-item choice-item--checkbox">
             <input
               type="checkbox"
-              name="selected_choice_ids[]"
+              name="selected_choice_id[]"
               id="choice_<%= choice.id %>"
               value="<%= choice.id %>"
               <%= "checked" if @selected_choice_ids&.include?(choice.id) %>
@@ -28,7 +28,7 @@
           <div class="choice-item">
             <input
               type="radio"
-              name="selected_choice"
+              name="selected_choice_id[]"
               id="choice_<%= choice.id %>"
               value="<%= choice.id %>"
               <%= "checked" if @selected_choice_ids&.include?(choice.id) %>


### PR DESCRIPTION
## 概要

QuizzesController の answer アクションをリファクタリング。
複数回答、単数回答、両方とも同じ id 配列で管理。

---

## 関連 Issue

- close #460 

---

## 変更内容

- QuizzesController  answer アクション
変更前
```ruby
    if @quiz.multiple_answer?
      ##### 複数選択問題の場合 #####
      # ユーザーが選択した回答 params[:selected_choice_ids]を整形して、変数に代入。
      selected_ids = Array(params[:selected_choice_ids]).map(&:to_i).uniq
      # 整形した回答を、session[:answers] に格納。
      session[:answers][@index - 1] = selected_ids
    else
      ##### 単一選択問題の場合 #####
      # 単一問題は、を session[:answers] に格納。
      session[:answers][@index - 1] = params[:selected_choice]
    end
```

変更後
```ruby
session[:answers][@index - 1] = Array(params[:selected_choice_id]).map(&:to_i)
```

_answer.html.erb のラジオボタンの name を変更
```
変更前
name="selected_choice"

変更後
name="selected_choice_ids[]"
```