### PR TITLE
quiz_answer_evaluator修正

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,7 +1,6 @@
 class QuizzesController < ApplicationController
   # 未ログインでも、クイズに挑戦できる。
-  skip_before_action :authenticate_user!, only: [ :start, :show, :answer, :guest_result ]
-
+  skip_before_action :authenticate_user!
   before_action :set_course
   before_action :set_quiz_data, only: [ :show, :answer ]
 
@@ -12,7 +11,6 @@ class QuizzesController < ApplicationController
   end
 
   def show
-    # 答え合わせのメソッドを実行（ブラウザの「戻る」で回答済みを復元）
     answer_check
     # 最後の問題用に、「結果発表」で飛ぶ先の id を覚えておく
     @course_result_id = params[:result_id].presence&.to_i

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -20,8 +20,4 @@ class Quiz < ApplicationRecord
   has_many :quiz_categories, dependent: :destroy
   has_many :categories, through: :quiz_categories
 
-  # 複数選択肢クイズなのか判定するメソッド
-  def multiple_answer?
-    choices.where(is_correct: true).count > 1
-  end
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -19,5 +19,4 @@ class Quiz < ApplicationRecord
 
   has_many :quiz_categories, dependent: :destroy
   has_many :categories, through: :quiz_categories
-
 end

--- a/app/services/quiz_answer_evaluator.rb
+++ b/app/services/quiz_answer_evaluator.rb
@@ -1,6 +1,5 @@
 # クイズの正誤判定などを行うクラス
 class QuizAnswerEvaluator
-
   def self.call(quiz:, answer:)
     self.new(quiz:, answer:)
   end
@@ -34,5 +33,4 @@ class QuizAnswerEvaluator
   def correct?
     selected_ids.present? ? selected_ids == correct_ids : nil
   end
-
 end

--- a/app/services/quiz_answer_evaluator.rb
+++ b/app/services/quiz_answer_evaluator.rb
@@ -1,65 +1,38 @@
-# クイズの正誤判定を行うクラス
+# クイズの正誤判定などを行うクラス
 class QuizAnswerEvaluator
-  # クイズの結果を入れるための Result を定義。
-  Result = Struct.new(
-    :multiple_answer?,
-    :selected_ids,
-    :correct_ids,
-    :correct_choices,
-    :correct?,
-    keyword_init: true
-  )
 
-  # クラスメソッド
   def self.call(quiz:, answer:)
-    # QuizAnswerEvaluator.call で呼び出すことができるようにしている。
-    new(quiz:, answer:).call
+    self.new(quiz:, answer:)
   end
 
-  # クラスを new した際、インスタンス変数をセットする。
   def initialize(quiz:, answer:)
     @quiz = quiz
     @answer = answer
   end
 
-  # private 配下の各メソッドの戻り値を集めて Result を作成している。
-  def call
-    Result.new(
-      multiple_answer?: multiple_answer?,
-      selected_ids: selected_ids,
-      correct_ids: correct_ids,
-      correct_choices: correct_choices,
-      correct?: answered? ? selected_ids == correct_ids : nil
-    )
-  end
-
-  private
-
-  # @quiz と @answer を返す。
-  attr_reader :quiz, :answer
-
-  # 正解の選択肢が2つ以上なら true (複数選択問題)
+  # 複数選択肢のクイズなのか判定
   def multiple_answer?
-    quiz.multiple_answer?
+    @quiz.choices.where(is_correct: true).count > 1
   end
 
-  # answer を、整数の・重複なし・並び順統一済みの配列に変える
+  # ユーザーが選択した回答一覧
   def selected_ids
-    @selected_ids ||= Array(answer).sort
+    @selected_ids ||= Array(@answer).sort
   end
 
   # 正解選択肢の id 一覧
   def correct_ids
-    @correct_ids ||= quiz.choices.where(is_correct: true).pluck(:id).sort
+    @correct_ids ||= @quiz.choices.where(is_correct: true).pluck(:id).sort
   end
 
   # 正解選択肢のオブジェクト一覧
   def correct_choices
-    @correct_choices ||= quiz.choices.where(id: correct_ids)
+    @correct_choices ||= @quiz.choices.where(id: correct_ids)
   end
 
-  # 未回答であれば false 回答済みであれば true
-  def answered?
-    selected_ids.present?
+  # 正誤判定のメソッド
+  def correct?
+    selected_ids.present? ? selected_ids == correct_ids : nil
   end
+
 end


### PR DESCRIPTION
## 概要

QuizAnswerEvaluator の Result Struct を削除し、1クラスで完結する設計に変更した。

---

## 関連 Issue

- close #465 

---

## 変更内容

- `Result = Struct.new(...)` を削除
- `def call` を削除し、`self.call` がインスタンスを直接返すように変更
- 各メソッドを public に移動
- `Quiz#multiple_answer?` を `QuizAnswerEvaluator` に移動して削除
- `QuizzesController` の `skip_before_action` から `only:` を削除

---

## 備考

quiz モデルから、multiple_answer? を削除し、QuizAnswerEvaluator に定義。
