### PR TITLE
resultリファクタリング

### DIFF
--- a/app/models/course_result.rb
+++ b/app/models/course_result.rb
@@ -19,15 +19,14 @@ class CourseResult < ApplicationRecord
       user: user,
       course: course,
       correct_count: 0,
-      total_questions: total_questions,
-      finished_at: Time.current
+      total_questions: total_questions
     )
 
     # クイズ履歴、選択肢を作成
     tally = course_result.build_quiz_histories!(quiz_ids: quiz_ids, answers: answers)
 
     # 正解数を最新の状態にアップデート
-    course_result.update!(correct_count: tally[:correct_count])
+    course_result.update!(correct_count: tally[:correct_count]) if tally[:correct_count].positive?
 
     # ユーザーの合計ポイントに加算
     user.increment!(:total_point, tally[:earned_point]) if tally[:earned_point].positive?
@@ -55,7 +54,7 @@ class CourseResult < ApplicationRecord
       evaluation = QuizAnswerEvaluator.call(quiz: quiz, answer: answers[index])
 
       # クイズ１問分の履歴を作成
-      quiz_history = quiz_histories.create!(user: user, quiz: quiz)
+      quiz_history = quiz_histories.create!(quiz: quiz)
 
       # クイズの選択肢の履歴を作成
       evaluation.selected_ids.each do |choice_id|

--- a/app/models/quiz_history.rb
+++ b/app/models/quiz_history.rb
@@ -1,6 +1,5 @@
 class QuizHistory < ApplicationRecord
   ##### アソシエーション #####
-  belongs_to :user
   belongs_to :course_result
   belongs_to :quiz
 

--- a/db/migrate/20260623105245_remove_finished_at_from_course_results.rb
+++ b/db/migrate/20260623105245_remove_finished_at_from_course_results.rb
@@ -1,0 +1,5 @@
+class RemoveFinishedAtFromCourseResults < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :course_results, :finished_at, :datetime
+  end
+end

--- a/db/migrate/20260623105255_remove_user_id_from_quiz_histories.rb
+++ b/db/migrate/20260623105255_remove_user_id_from_quiz_histories.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromQuizHistories < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :quiz_histories, :user_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_20_062235) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_23_105255) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -81,7 +81,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_20_062235) do
     t.bigint "course_id", null: false
     t.integer "correct_count", default: 0, null: false
     t.integer "total_questions", default: 0, null: false
-    t.datetime "finished_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_course_results_on_course_id"
@@ -116,14 +115,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_20_062235) do
   end
 
   create_table "quiz_histories", force: :cascade do |t|
-    t.bigint "user_id", null: false
     t.bigint "course_result_id", null: false
     t.bigint "quiz_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_result_id"], name: "index_quiz_histories_on_course_result_id"
     t.index ["quiz_id"], name: "index_quiz_histories_on_quiz_id"
-    t.index ["user_id"], name: "index_quiz_histories_on_user_id"
   end
 
   create_table "quiz_history_choices", force: :cascade do |t|
@@ -211,7 +208,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_20_062235) do
   add_foreign_key "quiz_categories", "quizzes"
   add_foreign_key "quiz_histories", "course_results", on_delete: :cascade
   add_foreign_key "quiz_histories", "quizzes"
-  add_foreign_key "quiz_histories", "users"
   add_foreign_key "quiz_history_choices", "choices"
   add_foreign_key "quiz_history_choices", "quiz_histories", on_delete: :cascade
   add_foreign_key "user_badges", "users"

--- a/spec/system/results_spec.rb
+++ b/spec/system/results_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe "Results", type: :system do
       user: user,
       course: course,
       correct_count: 1,
-      total_questions: 2,
-      finished_at: Time.current
+      total_questions: 2
     )
   end
 
@@ -41,8 +40,8 @@ RSpec.describe "Results", type: :system do
   let!(:second_wrong_choice) { Choice.create!(quiz: second_quiz, text: '問題2の不正解', is_correct: false) }
 
   # course_result にぶら下がる各問題の回答履歴。
-  let!(:first_history) { QuizHistory.create!(user: user, course_result: course_result, quiz: first_quiz) }
-  let!(:second_history) { QuizHistory.create!(user: user, course_result: course_result, quiz: second_quiz) }
+  let!(:first_history) { QuizHistory.create!(course_result: course_result, quiz: first_quiz) }
+  let!(:second_history) { QuizHistory.create!(course_result: course_result, quiz: second_quiz) }
 
   let!(:first_history_choice) { QuizHistoryChoice.create!(quiz_history: first_history, choice: first_correct_choice) }
   let!(:second_history_choice) { QuizHistoryChoice.create!(quiz_history: second_history, choice: second_wrong_choice) }


### PR DESCRIPTION
## 概要

不要なカラムの削除とそれに伴うコードのリファクタリング

---

## 関連 Issue

- close #468 

---

## 変更内容

### DB変更
course_results テーブルから finished_at カラムを削除
created_at で代替可能なため不要
quiz_histories テーブルから user_id カラムを削除
course_results に user_id があるため冗長

### コード変更
app/models/course_result.rb

CourseResult.create! から finished_at: Time.current を削除
course_result.update! に if tally[:correct_count].positive? を追記（全問不正解時の無駄なクエリを防ぐ）
quiz_histories.create! から user: user を削除
app/models/quiz_history.rb

belongs_to :user を削除
spec/system/results_spec.rb

CourseResult.create! から finished_at: Time.current を削除
QuizHistory.create! から user: user を削除


---

## 備考

