### PR TITLE
カラム削除

### DIFF
--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -1,6 +1,6 @@
 class UserBadge < ApplicationRecord
   ##### バリデーション #####
-  validates :badge_type, :acquired_at, presence: true
+  validates :badge_type, presence: true
 
   ##### アソシエーション #####
   belongs_to :user

--- a/app/services/badge_grant_service.rb
+++ b/app/services/badge_grant_service.rb
@@ -66,7 +66,6 @@ class BadgeGrantService
     # @user の user_badges レコードを作成。
     @user.user_badges.create!(
       badge_type: badge_type,
-      acquired_at: Time.current,
       notified_at: notified ? Time.current : nil
       )
   end

--- a/db/migrate/20260628070033_remove_acquired_at_from_user_badges.rb
+++ b/db/migrate/20260628070033_remove_acquired_at_from_user_badges.rb
@@ -1,0 +1,5 @@
+class RemoveAcquiredAtFromUserBadges < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :user_badges, :acquired_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_23_105255) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_28_070033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -152,7 +152,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_23_105255) do
   create_table "user_badges", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "badge_type", null: false
-    t.datetime "acquired_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "notified_at"

--- a/spec/factories/user_badges.rb
+++ b/spec/factories/user_badges.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :user_badge do
     association :user
     badge_type { :white_belt }
-    acquired_at { Time.current }
     notified_at { nil }
   end
 end

--- a/spec/models/user_badge_spec.rb
+++ b/spec/models/user_badge_spec.rb
@@ -6,11 +6,6 @@ RSpec.describe UserBadge, type: :model do
       badge = build(:user_badge, badge_type: nil)
       expect(badge).not_to be_valid
     end
-
-    it 'acquired_at がなければ無効である' do
-      badge = build(:user_badge, acquired_at: nil)
-      expect(badge).not_to be_valid
-    end
   end
 
   describe 'アソシエーション' do


### PR DESCRIPTION
## 概要

不要なカラムの削除とそれに伴うコードのリファクタリング

---

## 関連 Issue

- close #471 


---

## 変更内容

---

DB変更
course_results テーブルから finished_at カラムを削除
created_at で代替可能なため不要
quiz_histories テーブルから user_id カラムを削除
course_results に user_id があるため冗長
user_badges テーブルから acquired_at カラムを削除
created_at で代替可能なため不要

---

コード変更
app/models/course_result.rb

CourseResult.create! から finished_at: Time.current を削除
course_result.update! に if tally[:correct_count].positive? を追記（全問不正解時の無駄なクエリを防ぐ）
quiz_histories.create! から user: user を削除
app/models/quiz_history.rb

belongs_to :user を削除
app/models/user_badge.rb

バリデーションから acquired_at を削除
app/services/badge_grant_service.rb

UserBadge.create! から acquired_at: Time.current を削除

---

テスト変更
spec/system/results_spec.rb

CourseResult.create! から finished_at: Time.current を削除
QuizHistory.create! から user: user を削除
spec/models/user_badge_spec.rb

acquired_at のバリデーションテストを削除
spec/factories/user_badges.rb

acquired_at { Time.current } を削除


