### PR TITLE
fix: フォームバリデーションエラー時にナビ付きフッターが誤表示される不具合を修正

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,9 +3,9 @@
 
 <!----- トップページ、新規登録、ログイン、パスワード変更画面にはナビを表示させない --->
   <% if !current_page?(root_path) &&
-        !current_page?(new_user_registration_path) &&
-        !current_page?(new_user_session_path) &&
-        !(controller_name == "passwords" && %w[new edit].include?(action_name)) %>
+        !(controller_name == "registrations" && ["new", "create"].include?(action_name)) &&
+        !(controller_name == "sessions" && ["new", "create"].include?(action_name)) &&
+        !(controller_name == "passwords" && ["new", "edit", "create", "update"].include?(action_name)) %>
 
 <!--------- ナビ -------->
     <nav class="footer-nav">


### PR DESCRIPTION
## 概要

新規登録画面でフォームを未入力のまま送信し、バリデーションエラーが表示された際に、
本来非表示であるべき「ナビ付きフッター」（クイズ・家族ルームなどのリンク）が
表示されてしまう不具合を修正しました。

---

## 関連 Issue

- close #456 


---

## 修正内容
`current_page?` によるURL・GET判定から、`controller_name` / `action_name` による
コントローラー名・アクション名ベースの判定に変更しました。
これによりHTTPメソッド（GET/POST/PATCH）に関わらず、同一画面であれば
一貫してナビの表示/非表示を判定できるようになります。

- `registrations` コントローラー: `new`（サインアップ画面）/ `create`（サインアップ失敗時）
- `sessions` コントローラー: `new`（ログイン画面）/ `create`（ログイン失敗時）
- `passwords` コントローラー: `new` / `edit` に加え、`create`（再設定メール送信失敗時）/
  `update`（パスワード再設定失敗時）も追加


