### PR TITLE
fix: マイページのバッジ獲得日表示でNoMethodErrorが発生する不具合を修正

### DIFF
--- a/app/views/users/users/show.html.erb
+++ b/app/views/users/users/show.html.erb
@@ -42,7 +42,7 @@
               </div>
               <div class="badge-info">
                 <span class="badge-name"><%= UserBadge::BADGE_NAMES[badge.badge_type.to_sym] %></span>
-                <span class="badge-date"><%= badge.acquired_at.strftime("%Y.%m.%d") %> 獲得</span>
+                <span class="badge-date"><%= badge.created_at.strftime("%Y.%m.%d") %> 獲得</span>
                 <span class="badge-description"><%= UserBadge::BADGE_DESCRIPTIONS[badge.badge_type.to_sym] %></span>
               </div>
             </li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -101,7 +101,6 @@ ja:
         user: ユーザー
         user_id: ユーザー
         badge_type: バッジ種類
-        acquired_at: 取得日時
         created_at: 作成日
         updated_at: 更新日
 


### PR DESCRIPTION
## 概要
マイページ（users/show）のバッジ一覧で、獲得日を表示する際に `NoMethodError` が発生していた不具合を修正しました。

## 原因
`user_badges` テーブルの `acquired_at` カラムは既に削除済みで、獲得日時は `created_at` で管理する方針になっていました。
しかし `app/views/users/users/show.html.erb` に削除前の `acquired_at` を参照するコードが残っており、存在しないカラムを呼び出してエラーになっていました。

## 対応内容
- `badge.acquired_at.strftime("%Y.%m.%d")` → `badge.created_at.strftime("%Y.%m.%d")` に修正
- `config/locales/ja.yml` に残っていた `acquired_at` の日本語訳定義を削除（不要な項目のため）
