### PR TITLE
バリデーションエラーのフラッシュメッセージ化

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,2 +1,15 @@
 class Users::PasswordsController < Devise::PasswordsController
+  def create
+    super { |resource| set_error_flash(resource) }
+  end
+
+  def update
+    super { |resource| set_error_flash(resource) }
+  end
+
+  private
+
+  def set_error_flash(resource)
+    flash.now[:alert] = resource.errors.full_messages.join("、") if resource.errors.any?
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,6 +7,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
   before_action :set_badges, only: [ :edit, :update ]
   before_action :configure_account_update_params, only: [ :update ]
 
+  def create
+    super do |resource|
+      flash.now[:alert] = resource.errors.full_messages.join("、") if resource.errors.any?
+    end
+  end
+
   protected
 
   # サインアップ後、remember_me を適用させる（ログイン状態保持）

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -7,9 +7,6 @@
     </div>
 
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-      <div class="form-errors">
-        <%= render "users/shared/error_messages", resource: resource %>
-      </div>
 
       <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -12,10 +12,6 @@
           url: password_path(resource_name),
           html: { method: :post }) do |f| %>
 
-      <div class="form-errors">
-        <%= render "users/shared/error_messages", resource: resource %>
-      </div>
-
       <div class="form-field form-field--last">
         <%= f.label :email, class: "form-label" %>
         <%= f.email_field :email,

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -13,10 +13,6 @@
     </div>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <div class="form-errors">
-        <%= render "users/shared/error_messages", resource: resource %>
-      </div>
-
       <div class="form-field">
         <%= f.label :name, class: "form-label" %>
         <%= f.text_field :name, autofocus: true, autocomplete: "name",


### PR DESCRIPTION
## 概要
新規登録・パスワード再設定でのバリデーションエラー表示を、ログイン（sessions）と同じフラッシュメッセージ形式に統一しました。

## 関連 Issue

- close #480 

## 背景
- sessions（ログイン）はDevise標準機能により、認証失敗時に自動で flash[:alert] がセットされ、レイアウト共通の shared/_flash_message で表示されている
- registrations（新規登録）・passwords（パスワード再設定）は resource.errors を使った独自の箇条書き表示（_error_messages パーシャル）になっており、見た目・実装方法が異なっていた

## 変更内容
- Users::RegistrationsController#create をオーバーライドし、バリデーションエラー時に flash.now[:alert] へ具体的なエラー内容をセット
- Users::PasswordsController#create / #update も同様にオーバーライド
- 上記に伴い、registrations/new.html.erb・passwords/new.html.erb・passwords/edit.html.erb から箇条書きエラー表示（_error_messages パーシャル呼び出し）を削除

## 動作確認
- 新規登録フォームで未入力のまま送信し、sessionsと同じ見た目でエラー内容が表示されることを確認
- パスワード再設定（メール送信・新パスワード設定）でも同様に確認
- エラー表示後に別ページへ遷移してもフラッシュメッセージが残らないことを確認
このプルリクで何をしたか、簡単に書いてください。
