### PR TITLE
homeのアニメーション作成

### DIFF
--- a/app/javascript/controllers/home_controller.js
+++ b/app/javascript/controllers/home_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["category_grid"]
+
+  connect(){
+    const category_grid = this.category_gridTarget //category_grid 要素を取得
+
+    //===== category_grid のアニメーション =====
+
+    // 下から浮き上がるアニメーション ==
+    const show_category_grid = (entries) => {
+      const keyframes = {
+        opacity: [0, 1],
+        translate: ['0 45px', 0],
+      }
+
+      const options = {
+        duration: 1000,
+        easing: 'ease',
+      };
+
+      if(entries[0].isIntersecting) {
+      entries[0].target.animate(keyframes, options);}
+    }
+
+
+    // ===== 監視ロボットの設定 =====
+    const category_gridObserver = new IntersectionObserver(show_category_grid);
+
+    // ===== 要素を監視するよう指示 ====
+    category_gridObserver.observe(category_grid);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("quiz-scroll", QuizScrollController)
 
 import TopController from "./top_controller"
 application.register("top", TopController)
+
+import HomeController from "./home_controller"
+application.register("home", HomeController)

--- a/app/views/homes/home.html.erb
+++ b/app/views/homes/home.html.erb
@@ -4,7 +4,7 @@
     <!-- お知らせブロック -->
     <div class="announcement-section">
       <h2 class="section-title">お知らせ</h2>
-      
+
       <div class="announcement-card">
         <% if @announcements.present? %>
           <ul class="announcement-list">
@@ -13,7 +13,7 @@
                 <div class="announcement-date">
                   <%= announcement.published_at&.strftime("%Y年%m月%d日") %>
                 </div>
-                
+
                 <% if announcement.url.present? %>
                   <%= link_to announcement.url, class: "announcement-title announcement-link" do %>
                     <span><%= announcement.title %></span>
@@ -25,7 +25,7 @@
                 <% else %>
                   <h3 class="announcement-title"><%= announcement.title %></h3>
                 <% end %>
-                
+
                 <% if announcement.body.present? %>
                   <p class="announcement-body"><%= announcement.body %></p>
                 <% end %>
@@ -83,10 +83,10 @@
 
     <!-- カテゴリー一覧 -->
     <!-- カテゴリーを追加すれば,ヘルパーに追記すること-->
-    <div>
+    <div data-controller="home">
       <h2 class="section-title">本日の稽古（カテゴリー選択）</h2>
 
-      <div class="category-grid">
+      <div class="category-grid" data-home-target="category_grid">
         <% @categories.each do |category| %>
           <%= link_to category_courses_path(category), class: "category-card" do %>
             <div class="category-icon-wrapper">


### PR DESCRIPTION
## 概要

ホーム画面（本日の稽古／カテゴリー選択エリア）に、スクロールして画面内に入った際にフェードイン＋下から浮き上がるアニメーションを追加。

---

## 関連 Issue

- close #482 

---

## 変更内容
- `app/javascript/controllers/home_controller.js` を新規追加
  - IntersectionObserver でカテゴリー一覧（`category-grid`）が画面内に入ったことを検知し、`element.animate()` でフェードイン＋上方向への移動アニメーションを実行
- `app/javascript/controllers/index.js`
  - `HomeController` を登録
- `app/views/homes/home.html.erb`
  - カテゴリー一覧のブロックに `data-controller="home"` / `data-home-target="category_grid"` を追加
  - 末尾の余分な空白を削除（インデント整形）

