### PR TITLE
LINE機能のリファクタリング

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -19,12 +19,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         password_confirmation: password)
       user.save!
     end
-    user.set_values(auth)
     sign_in(:user, user)
     redirect_to home_path, notice: "ログインしました"
-  end
-
-  def fake_email(uid, provider)
-    "#{auth.uid}-#{auth.provider}@example.com"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,27 +53,6 @@ class User < ApplicationRecord
     clean_up_passwords
     result
   end
-
-  ##### LINE ログインに必要な記述 #####
-  def social_profile(provider)
-    social_profiles.select { |sp| sp.provider == provider.to_s }.first
-  end
-
-  def set_values(omniauth)
-    return if provider.to_s != omniauth["provider"].to_s || uid != omniauth["uid"]
-    credentials = omniauth["credentials"]
-    info = omniauth["info"]
-
-    access_token = credentials["refresh_token"]
-    access_secret = credentials["secret"]
-    credentials = credentials.to_json
-    name = info["name"]
-  end
-
-  def set_values_by_raw_info(raw_info)
-    self.raw_info = raw_info.to_json
-    self.save!
-  end
 end
 
 #####  メモ   #####


### PR DESCRIPTION
## 概要
LINEログイン機能のコードを読み直したところ、実際には使われていない、または呼び出すとエラーになるメソッドが見つかったため削除しました。

## 変更内容
- `app/models/user.rb`
  - `social_profile`：`social_profiles`という未定義の関連を参照しており、呼び出し元も存在しない
  - `set_values`：中身がローカル変数への代入のみで、DBには何も反映されない実質空のメソッド
  - `set_values_by_raw_info`：存在しない`raw_info`カラムに代入しており、呼び出すとエラーになる。呼び出し元もなし
- `app/controllers/omniauth_callbacks_controller.rb`
  - `user.set_values(auth)`：上記の空メソッドの呼び出しを削除
  - `fake_email`：未定義の変数`auth`を参照しておりエラーになる。呼び出し元もなし

## 関連 Issue

- close #488 

## 動作確認
- ブラウザでLINEログイン（新規登録・既存ユーザーでのログイン）が問題なく動作することを確認済み

## 補足
`user.save!`を`save`に変更する対応（バリデーション失敗時の挙動改善）は、動作を変える変更のため別issueとして切り出す予定です。

