### PR TITLE
LINE機能の修正

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
         name: auth.dig("info", "name"),
         password: password,
         password_confirmation: password)
-      user.save!
+      return redirect_to new_user_session_path, alert: "アカウントを作成できませんでした" unless user.save
     end
     sign_in(:user, user)
     redirect_to home_path, notice: "ログインしました"


### PR DESCRIPTION
## 概要
LINEログインで新規アカウント作成時、バリデーション（emailの一意性など）に失敗した場合に`save!`が例外を投げ、ユーザーにRailsのエラー画面が表示されてしまう問題を修正。

想定される失敗ケースの例：
- 既にメールアドレス＋パスワードでアカウントを持っているユーザーが、同じメールアドレスのLINEアカウントで初めて「LINEでログイン」した場合、emailの一意性違反で保存に失敗する
---

## 関連 Issue

- close #490 

---

## 変更内容
`app/controllers/omniauth_callbacks_controller.rb`
- `user.save!` → `user.save`に変更
- 保存に失敗した場合は、例外で落とさずログイン画面（`new_user_session_path`）に「アカウントを作成できませんでした」というメッセージ付きでリダイレクトするように変更

