### PR TITLE
一問一答機能を追加

### DIFF
--- a/app/assets/stylesheets/results.css
+++ b/app/assets/stylesheets/results.css
@@ -627,6 +627,36 @@
 }
 
 /* =========================================
+  クイズ単体シェア画面 (shared_quizzes)
+   ========================================= */
+
+/* 「他のクイズに挑戦」ボタン */
+.btn-next-quiz {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1.5rem;
+  margin-bottom: 3rem;
+  padding: 0.8rem 2rem;
+  background-color: #C63D2F;
+  color: #fff;
+  font-family: 'Noto Serif JP', serif;
+  font-weight: 700;
+  font-size: 1rem;
+  border-radius: 9999px;
+  text-decoration: none;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s ease;
+}
+
+.btn-next-quiz:hover {
+  background-color: #a8321f;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+  color: #fff;
+}
+
+/* =========================================
   共有リンク失効画面
    ========================================= */
 .share-expired-card {

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -36,7 +36,7 @@ class ResultsController < ApplicationController
     # .signed_id でトークンを作成している（Rails標準機能）
     token = @course_result.signed_id(purpose: :share_result, expires_in: 30.days)
 
-    # 上で作った token をURLに埋め込んで、共有用URLを作る。
+    # 上で作った token をURLに埋め込んで、成績共有用URLを作る。
     @share_url = share_result_url(token: token)
   end
 

--- a/app/controllers/shared_quizzes_controller.rb
+++ b/app/controllers/shared_quizzes_controller.rb
@@ -1,0 +1,30 @@
+class SharedQuizzesController < ApplicationController
+  skip_before_action :authenticate_user!
+  before_action :set_quiz_data, only: [ :show, :answer ]
+
+  def show
+  end
+
+  def answer
+    answer = Array(params[:selected_choice_id]).map(&:to_i)
+    result = QuizAnswerEvaluator.call(quiz: @quiz, answer: answer)
+
+    # view で使用するインスタンス変数をセット
+    @is_correct = result.correct?
+    @selected_choice_ids = result.selected_ids
+    @correct_choices = result.correct_choices
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { render :show }
+    end
+  end
+
+  private
+
+  def set_quiz_data
+    @quiz = Quiz.includes(:choices).find(params[:id])
+    @choices = @quiz.choices
+    @multiple_answer = @quiz.choices.where(is_correct: true).count > 1
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,6 @@
       </div>
     <% end %>
 
-    <%= render "shared/footer" %>
+    <%= render "shared/footer" unless controller_name == "shared_quizzes" %>
   </body>
 </html>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -23,7 +23,7 @@
       </div>
     </div>
 
-    <!----- X シェアボタン (デザイン適用) ----->
+    <!----- 成績の X シェアボタン ----->
     <% if @course_result.user_id == current_user.id %>
       <% tweet_text = "「#{@course_result.course.category.name}」「#{@course_result.course.name}」コース\n#{@course_result.total_questions}問中、#{@course_result.correct_count}問正解。" %>
       <% intent_url = "https://twitter.com/intent/tweet?text=#{CGI.escape(tweet_text)}&url=#{CGI.escape(@share_url)}&hashtags=詐欺対策道場" %>
@@ -34,7 +34,7 @@
           <svg class="icon-x-logo" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
           </svg>
-          <span>結果をポストする</span>
+          <span>成績をポストする</span>
         <% end %>
       </div>
     <% end %>
@@ -101,6 +101,22 @@
         <div class="history-explanation">
           <span class="explanation-label">【解説】</span>
           <p class="history-explanation-text"><%= auto_link(quiz.explanation, sanitize: true, html: { target: "_blank", rel: "noopener noreferrer nofollow" }) %></p>
+        </div>
+      <% end %>
+
+      <!----- クイズの X シェアボタン  ----->
+      <% if @course_result.user_id == current_user.id %>
+        <% tweet_text = "#{@course_result.course.category.name}クイズ\n一問一答の詐欺対策クイズに挑戦しよう" %>
+        <% intent_url = "https://twitter.com/intent/tweet?text=#{CGI.escape(tweet_text)}&url=#{CGI.escape(share_quiz_url(quiz.id))}&hashtags=詐欺対策道場" %>
+
+        <div class="share-area">
+          <%= link_to intent_url, target: "_blank", rel: "noopener noreferrer", class: "btn-share-x" do %>
+            <%# X (Twitter) ロゴSVG %>
+            <svg class="icon-x-logo" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
+            </svg>
+            <span>このクイズを共有する</span>
+          <% end %>
         </div>
       <% end %>
 

--- a/app/views/shared_quizzes/_result.html.erb
+++ b/app/views/shared_quizzes/_result.html.erb
@@ -1,0 +1,46 @@
+<!------ 判定結果表示エリア ------->
+<% unless @is_correct.nil? %>
+  <div class="result-container">
+    <% if @is_correct %>
+      <!------ 正解時の表示 ------>
+      <div class="result-box--correct">
+        <div class="result-title--correct">
+          <span class="result-mark">◎</span> 見事！正解
+        </div>
+      </div>
+    <% else %>
+      <!------ 不正解時の表示 ------>
+      <div class="result-box--incorrect">
+        <div class="result-title--incorrect">
+          <span class="result-mark">✕</span> 無念...不正解
+        </div>
+      </div>
+    <% end %>
+
+    <!------ 正解と解説 ------->
+    <div class="explanation-box">
+      <div class="mb-4">
+        <span class="explanation-title text-[#C63D2F]">【正解】</span>
+        <ul class="list-disc list-inside font-bold text-lg text-gray-800">
+          <% if @correct_choices.present? %>
+            <% @correct_choices.each do |correct| %>
+              <li><%= correct.text %></li>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+
+      <% if @quiz.explanation.present? %>
+        <div>
+          <span class="explanation-title">【解説】</span>
+          <p class="quiz-explanation"><%= auto_link(@quiz.explanation, html: { target: "_blank", rel: "noopener noreferrer nofollow" }) %></p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="share-action-wrapper">
+    <%= link_to "他のクイズに挑戦", home_path, class: "btn-next-quiz" %>
+  </div>
+
+<% end %>

--- a/app/views/shared_quizzes/answer.turbo_stream.erb
+++ b/app/views/shared_quizzes/answer.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "quiz_result_area" do %>
+  <%= render "shared_quizzes/result" %>
+<% end %>

--- a/app/views/shared_quizzes/show.html.erb
+++ b/app/views/shared_quizzes/show.html.erb
@@ -1,0 +1,51 @@
+<div class="quiz-container"
+    data-controller="quiz-scroll"
+    data-action="turbo:submit-end@document->quiz-scroll#scrollToResult">
+
+  <!------ 判定結果エリア ------->
+  <div id="quiz_result_area" data-quiz-scroll-target="resultArea">
+    <%= render "shared_quizzes/result" %>
+  </div>
+
+  <!------ クイズカード ------->
+  <div class="quiz-card">
+
+    <p class="quiz-sentence"><%= @quiz.sentence %></p>
+
+    <% if @quiz.image.attached? %>
+      <div class="quiz-image-container">
+        <%= image_tag @quiz.image, class: "quiz-image" %>
+      </div>
+    <% end %>
+
+    <!------ 回答エリア ------->
+    <div id="quiz_answer_area">
+      <%= form_with url: answer_share_quiz_path(@quiz.id), method: :post,
+                    data: { quiz_scroll_form: true } do |form| %>
+        <div class="quiz-choices">
+          <% if @multiple_answer %>
+            <p class="text-sm text-gray-500 font-bold mb-2">※複数選択可</p>
+          <% end %>
+          <% @choices.each do |choice| %>
+            <div class="choice-item <%= @multiple_answer ? 'choice-item--checkbox' : '' %>">
+              <input
+                type="<%= @multiple_answer ? 'checkbox' : 'radio' %>"
+                name="selected_choice_id[]"
+                id="choice_<%= choice.id %>"
+                value="<%= choice.id %>"
+              >
+              <label for="choice_<%= choice.id %>" class="choice-label">
+                <%= choice.text %>
+              </label>
+            </div>
+          <% end %>
+        </div>
+
+        <div class="quiz-actions">
+          <%= form.submit "回答する", class: "quiz-submit-btn", data: { turbo_submits_with: "判定中..." } %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,10 @@ Rails.application.routes.draw do
     end
   end
 
+  ##### クイズシェア用 X などのリンクからきた一問一答 #####
+  get "share/quiz/:id", to: "shared_quizzes#show", as: :share_quiz
+  post "share/quiz/:id/answer", to: "shared_quizzes#answer", as: :answer_share_quiz
+
   ##### 成績表示のルーティング #####
   get "results/users", to: "results#users", as: :result_users
   get "share/results/:token", to: "share_results#show", as: :share_result

--- a/spec/system/shared_quizzes_spec.rb
+++ b/spec/system/shared_quizzes_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe "SharedQuizzes", type: :system do
+  let!(:quiz) do
+    Quiz.create!(
+      name: 'テストクイズ',
+      sentence: 'これはテスト問題です',
+      explanation: 'これはテスト解説です',
+      give_point: 10
+    )
+  end
+  let!(:correct_choice) { Choice.create!(quiz: quiz, text: '正しい選択肢', is_correct: true) }
+  let!(:wrong_choice)   { Choice.create!(quiz: quiz, text: '誤った選択肢', is_correct: false) }
+
+  describe '未ログインでのクイズ挑戦' do
+    it '問題が表示され、正解を選ぶと正誤判定と解説が表示されること' do
+      visit share_quiz_path(quiz)
+
+      expect(page).to have_content(quiz.sentence)
+
+      choose correct_choice.text
+      click_button '回答する'
+
+      expect(page).to have_content('見事！正解')
+      expect(page).to have_content(quiz.explanation)
+      expect(page).to have_link('他のクイズに挑戦', href: home_path)
+    end
+
+    it '不正解を選ぶと不正解の判定が表示されること' do
+      visit share_quiz_path(quiz)
+
+      choose wrong_choice.text
+      click_button '回答する'
+
+      expect(page).to have_content('無念...不正解')
+      expect(page).to have_content(correct_choice.text)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Xでのクイズ拡散機能：一問一答の共有ページを追加

アプリの新規ユーザー獲得のため、クイズを1問単位でXにシェアできる機能を追加しました。
結果画面から個別のクイズをXに投稿すると、リンクを踏んだ人は未ログインのままその1問だけに挑戦でき、正誤判定・解説を見た後にアプリのトップへ誘導されます。

---

## 関連 Issue

- close #496 

---

## 変更内容

### ルーティング

- GET /share/quiz/:id、POST /share/quiz/:id/answer を追加（config/routes.rb）

### コントローラー

- SharedQuizzesController を新規作成
- authenticate_user! を無効化し、未ログインでもアクセス可能に
- show：クイズと選択肢を取得して表示
- answer：QuizAnswerEvaluator（既存の正誤判定サービス）を再利用して判定
- JavaScriptが無効な環境でも動作するよう、turbo_stream に加えて html 形式のフォールバックにも対応

### View

- shared_quizzes/show.html.erb：問題文・回答フォーム（1問完結、進捗表示なし）
- shared_quizzes/_result.html.erb：正誤判定・解説・「他のクイズに挑戦」ボタンをまとめたパーシャル
- shared_quizzes/answer.turbo_stream.erb：回答後、結果エリアのみ非同期更新
- 結果画面（results/show.html.erb）

各設問カードに、その問題単体をXへ投稿できるシェアボタンを追加
投稿文には問題・答えを含めず、リンク先で内容を見てもらう形にして文字数制限の影響を回避

### レイアウト

一問一答の共有ページのみ、共通フッターを非表示に（application.html.erb）
テスト

### spec/system/shared_quizzes_spec.rb を新規作成

未ログイン状態で問題に回答し、正解・不正解それぞれの表示を確認

