### PR TITLE
家族ルームの説明追加

### DIFF
--- a/app/assets/stylesheets/rooms.css
+++ b/app/assets/stylesheets/rooms.css
@@ -5,6 +5,15 @@
   padding: 2rem 1rem;
 }
 
+/* --- 家族ルーム共通カード --- */
+.room-card {
+  padding: 4rem 2rem;
+  background: #fffcf5;
+  border-top: 4px solid #1F2F54;
+  border-radius: .75rem;
+  box-shadow: 0 25px 50px -12px rgba(0,0,0,.25);
+}
+
 /* --- メインヘッダー --- */
 .room-home-header {
   text-align: center;
@@ -130,7 +139,6 @@
 /* --- 未所属状態の表示 --- */
 .no-room-box {
   text-align: center;
-  padding: 4rem 2rem;
 }
 
 /* =========================================
@@ -205,18 +213,6 @@
   border-bottom: 2px solid #F7F3E8;
   position: relative;
   letter-spacing: 0.05em;
-}
-
-/* タイトル下の赤いアクセントライン */
-.room-new-title::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 300px;
-  height: 3px;
-  background-color: #C63D2F;
 }
 
 /* シンプルなエラーメッセージ表示 */

--- a/app/views/rooms/home.html.erb
+++ b/app/views/rooms/home.html.erb
@@ -57,11 +57,12 @@
   <% else %>
 
     <!------- 未所属状態 --------->
-    <div class="no-room-box animate-fade-in">
+    <div class="no-room-box room-card animate-fade-in">
       <h1 class="font-serif-jp text-2xl font-bold text-[#1F2F54] mb-4">家族ルームへようこそ</h1>
-      <p class="text-gray-600 mb-8 leading-relaxed">
-        家族ルームを作成して、大切な人と一緒に<br>
-        詐欺対策の修行を始めましょう。
+      <p class="text-gray-600 mb-8 leading-relaxed text-lg">
+        家族ルームを作成すると、招待した家族や友人と<br>
+        お互いのクイズの成績を見せ合うことができます。<br>
+        ランキングで競い合うこともできます。
       </p>
 
       <div class="flex flex-col gap-4 items-center">
@@ -69,7 +70,7 @@
           <i class="fas fa-plus-circle"></i>
           家族ルームを新しく作る
         <% end %>
-        <p class="text-sm text-gray-400 font-bold mt-4">または、招待されるのを待つ</p>
+        <p class="text-sm text-gray-600 font-bold mt-4">または、招待リンクで招待されるのを待つ</p>
       </div>
     </div>
 

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -1,6 +1,6 @@
-<div class="form-page animate-fade-in">
+<div class="room-container animate-fade-in">
 
-  <div class="form-card">
+  <div class="room-card">
     <h1 class="room-new-title">家族ルーム作成</h1>
 
     <!-- エラーメッセージ表示エリア -->


### PR DESCRIPTION
## 概要

「家族ルームが何をする機能か分からない」というフィードバックを受け、未所属時のトップ画面に説明文を追加

家族ルーム作成画面（new）のカードデザインを、トップ画面（home）と統一

---

## 関連 Issue

- close #498 

---

## 変更内容

- home.html.erb：未所属状態の説明文を「招待した家族や友人とお互いのクイズの成績を見せ合える」という具体的な内容に変更
- rooms.css：home・new共通のカードスタイル .room-card を新設し、重複していたスタイルを整理
- new.html.erb：カードの配置・見た目をhomeと統一

---

## 備考

