### PR TITLE
家族ルーム作成画面のエラー表示をflashメッセージに統一

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -251,7 +251,8 @@ select:-webkit-autofill{
 
 /* 　　　　エラー系の色　　　 */
 .flash-alert,
-.flash-error {
+.flash-error,
+.flash-danger {
   background: #fde2e1;
   color: #9b1c1c;
   border: 1px solid #f5a3a3;

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -18,7 +18,7 @@ class RoomsController < ApplicationController
       current_user.update!(room_id: @room.id)
       redirect_to home_rooms_path
     else
-      flash.now[:danger] = "家族ルームを作成出来ませんでした"
+      flash.now[:danger] = @room.errors.full_messages.join("、")
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -3,17 +3,6 @@
   <div class="room-card">
     <h1 class="room-new-title">家族ルーム作成</h1>
 
-    <!-- エラーメッセージ表示エリア -->
-    <% if @room.errors.any? %>
-      <div class="room-simple-error">
-        <ul>
-          <% @room.errors.full_messages.each do |message| %>
-            <li><i class="fas fa-exclamation-circle mr-1"></i><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-
     <!-----  フォーム ----->
     <%= form_with model: @room, local: true do |form| %>
 


### PR DESCRIPTION
## 概要

家族ルーム作成画面（new）で表示していたインラインのエラーメッセージを、共通のflashメッセージ表示に統一しました。

---

## 変更内容

- RoomsController#create: 保存失敗時のflashメッセージを固定文言からバリデーションエラー内容（@room.errors.full_messages）に変更
- RoomsController#new: 未定義のresourceを参照していた不要なコードを削除
- app/views/rooms/new.html.erb: インラインのエラー表示ブロックを削除し、レイアウト共通のflashパーシャルに一本化
- app/assets/stylesheets/application.tailwind.css: .flash-dangerを.flash-alert・.flash-errorと同じエラー系スタイル（赤系）に統一

---